### PR TITLE
Turn off problematic helm-diff three way merge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN set -ex && \
 
 ENV HELM_DIFF_COLOR=true
 ENV HELM_DIFF_IGNORE_UNKNOWN_FLAGS=true
-ENV HELM_DIFF_THREE_WAY_MERGE=true
 ENV HELM_DIFF_USE_UPGRADE_DRY_RUN=true
 RUN set -ex && \
     helm plugin install https://github.com/databus23/helm-diff --version v3.3.2 && \


### PR DESCRIPTION
It fails to compare non-installed release